### PR TITLE
Fix/fouc

### DIFF
--- a/src/components/NewsletterSignup.js
+++ b/src/components/NewsletterSignup.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import addToMailchimp from 'gatsby-plugin-mailchimp';
-import styled from 'react-emotion';
+import styled from '@emotion/styled';
 
 const NewsletterFormContainer = styled('div')`
   padding: 15px;

--- a/src/components/layout.js
+++ b/src/components/layout.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropType from 'prop-types';
-import styled from 'react-emotion';
+import styled from '@emotion/styled';
 import { MDXProvider } from '@mdx-js/react';
 import ThemeProvider from './themeProvider';
 import mdxComponents from './mdxComponents';

--- a/src/components/layout.js
+++ b/src/components/layout.js
@@ -2,6 +2,7 @@ import React from 'react';
 import PropType from 'prop-types';
 import styled from '@emotion/styled';
 import { MDXProvider } from '@mdx-js/react';
+import { Global, css } from '@emotion/core';
 import ThemeProvider from './themeProvider';
 import mdxComponents from './mdxComponents';
 import Sidebar from './sidebar';
@@ -46,6 +47,34 @@ const RightSideBarWidth = styled('div')`
 
 const Layout = ({ children, location }) => (
   <ThemeProvider location={location}>
+    <Global
+      styles={css`
+        * {
+          margin: 0;
+          padding: 0;
+          box-sizing: border-box;
+        }
+
+        html,
+        body {
+          font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto',
+            'Roboto Light', 'Oxygen', 'Ubuntu', 'Cantarell', 'Fira Sans',
+            'Droid Sans', 'Helvetica Neue', sans-serif, 'Apple Color Emoji',
+            'Segoe UI Emoji', 'Segoe UI Symbol';
+
+          font-size: 16px;
+        }
+
+        a {
+          transition: color 0.15s;
+          color: rgb(255, 162, 0);
+
+          &:hover {
+            color: rgb(255, 190, 0);
+          }
+        }
+      `}
+    />
     <MDXProvider components={mdxComponents}>
       <Wrapper>
         <LeftSideBarWidth className="hidden-xs">

--- a/src/components/mdxComponents/code.js
+++ b/src/components/mdxComponents/code.js
@@ -1,4 +1,4 @@
-import styled from 'react-emotion';
+import styled from '@emotion/styled';
 
 const Code = styled('code')`
   background: #f9f7fb;

--- a/src/components/notification.js
+++ b/src/components/notification.js
@@ -1,4 +1,4 @@
-import styled from 'react-emotion';
+import styled from '@emotion/styled';
 
 const notificationTypes = {
   warning: {

--- a/src/components/rightSidebar.js
+++ b/src/components/rightSidebar.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropType from 'prop-types';
 import { StaticQuery, graphql } from 'gatsby';
-import styled from 'react-emotion';
+import styled from '@emotion/styled';
 import './styles.css';
 import config from '../../config';
 

--- a/src/components/sidebar/index.js
+++ b/src/components/sidebar/index.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { StaticQuery, graphql } from 'gatsby';
-import styled from 'react-emotion';
+import styled from '@emotion/styled';
 import { ExternalLink } from 'react-feather';
 import Tree from './tree';
 import NewsletterSignup from '../NewsletterSignup';

--- a/src/html.js
+++ b/src/html.js
@@ -56,8 +56,11 @@ function HTML({
       </head>
       <body {...bodyAttributes}>
         {preBodyComponents}
-        <div key="body" id="___gatsby" dangerouslySetInnerHTML={{ __html: body }}>
-        </div>
+        <div
+          key="body"
+          id="___gatsby"
+          dangerouslySetInnerHTML={{ __html: body }}
+        ></div>
         {postBodyComponents}
       </body>
     </html>

--- a/src/templates/docs.js
+++ b/src/templates/docs.js
@@ -3,7 +3,7 @@ import PropType from 'prop-types';
 import Helmet from 'react-helmet';
 import { graphql } from 'gatsby';
 import MDXRenderer from 'gatsby-plugin-mdx/mdx-renderer';
-import styled, { injectGlobal } from 'react-emotion';
+import styled from '@emotion/styled';
 import { Layout, Link } from '../components';
 import NextPrevious from '../components/NextPrevious';
 import '../components/styles.css';
@@ -11,43 +11,6 @@ import config from '../../config';
 
 const { forcedNavOrder } = config.sidebar;
 const gitHub = require('../components/images/github.svg');
-
-injectGlobal`
-  * {
-    margin: 0;
-    padding: 0;
-    box-sizing: border-box;
-  }
-
-  html, body {
-    font-family: -apple-system,
-      BlinkMacSystemFont,
-      "Segoe UI",
-      "Roboto",
-      "Roboto Light",
-      "Oxygen",
-      "Ubuntu",
-      "Cantarell",
-      "Fira Sans",
-      "Droid Sans",
-      "Helvetica Neue",
-      sans-serif,
-      "Apple Color Emoji",
-      "Segoe UI Emoji",
-      "Segoe UI Symbol";
-
-    font-size: 16px;
-  }
-
-  a {
-    transition: color 0.15s;
-    color: rgb(255, 162, 0);
-
-    &:hover {
-      color: rgb(255, 190, 0);
-    }
-  }
-`;
 
 const Edit = styled('div')`
   padding: 1rem 1.5rem;


### PR DESCRIPTION
# Pull request checklist

Please check if your PR fulfills the following requirements:

- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [ ] Lint (`npm run lint`) has passed locally and any fixes were made for failures

linting error: `unable to resolve path to module '@emotion/styled'`. More details below

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Current behavior

A momentary flash of un-styled content is happening before Javascript has loaded

![current_open-brew-db](https://user-images.githubusercontent.com/47988669/79073867-ed93cd00-7cb6-11ea-8126-33d96fd1bb27.gif)


<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Fixes #20 

## New behavior

Page is now displaying properly on initial page load. No flash of wrong styling.

![new_open-brew-db](https://user-images.githubusercontent.com/47988669/79073903-2af85a80-7cb7-11ea-80d2-93958ab4153d.gif)


## Does this introduce a breaking change

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

### Overview of changes

#### New import syntax

One cause was how `styled` was being imported into all the files that use it. v10 of `emotion` required a slight change in the import.

```jsx
// previous import
import styled from "react-emotion";

// v10 import
import styled from "@emotion/styled";
```

[Import styled v10 docs](https://emotion.sh/docs/migrating-to-emotion-10#codemoddable)

#### Global Styling

How global styles are implemented in v10 also changed. `injectGlobal` needed to be replaced with the `Global` component. Additionally, the global styles needed to be moved into `layout.js` in order for them to take effect.

[Global styles in Gatsby with Emotion](https://www.gatsbyjs.org/docs/emotion/#adding-global-styles-in-gatsby-with-emotion)

#### Linting error
Because of the new import syntax ESlint is throwing an error, the build however is still successful.

`Unable to resolve path to module '@emotion/styled'  import/no-unresolved`

I was able to remove the error by adding `"import/no-unresolved": 0` into `.eslintrc.json`

#### Possible solutions found
https://stackoverflow.com/questions/55198502/using-eslint-with-typescript-unable-to-resolve-path-to-module

https://github.com/kriasoft/react-starter-kit/issues/1180

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
