### PR TITLE
Fix invalid URL

### DIFF
--- a/content/documentation.md
+++ b/content/documentation.md
@@ -9,4 +9,4 @@ metaDescription: "API Documentaton for Open Brewery DB"
 - [List Breweries](/documentation/01-listbreweries)
 - [Get Brewery](/documentation/02-getbrewery)
 - [Search Breweries](/documentation/03-search)
-- [Autocomplete](/documentation/03-autocomplete)
+- [Autocomplete](/documentation/04-autocomplete)


### PR DESCRIPTION
Updated the URL for the autocomplete endpoint documentation, as this was returning a 404.